### PR TITLE
Add case-sensitive string support in ABNF

### DIFF
--- a/abnf/abnf.abnf
+++ b/abnf/abnf.abnf
@@ -35,7 +35,13 @@ group          =  "(" *c-wsp alternation *c-wsp ")"
 
 option         =  "[" *c-wsp alternation *c-wsp "]"
 
-char-val       =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE
+char-val       =  case-insensitive-string / case-sensitive-string
+
+case-insensitive-string = [ "%i" ] quoted-string
+
+case-sensitive-string = "%s" quoted-string
+
+quoted-string  =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE
 					   ; quoted string of SP and VCHAR
 					   ;  without DQUOTE
 

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -650,10 +650,10 @@ class Matcher {
 
 	matchStringViaQuotedString(string) {
 		var
-			lowercase_string        = string.toLowerCase(),
-			lowercase_quoted_string = this.getQuotedString().toLowerCase();
+			string_to_match = this.node.isCaseSensitive() ? string : string.toLowerCase(),
+			quoted_string   = this.node.isCaseSensitive() ? this.getQuotedString() : this.getQuotedString().toLowerCase();
 
-		if (lowercase_string.indexOf(lowercase_quoted_string) !== 0) {
+		if (string_to_match.indexOf(quoted_string) !== 0) {
 			if (!string) {
 				throw new InputTooShortError(string, this.getNode());
 			} else {
@@ -666,7 +666,7 @@ class Matcher {
 		}
 
 		return {
-			string: string.slice(0, lowercase_quoted_string.length),
+			string: string.slice(0, quoted_string.length),
 			rules:  [ ]
 		};
 	}

--- a/lib/node.js
+++ b/lib/node.js
@@ -24,6 +24,21 @@ const BASES = {
 };
 
 /**
+ * An enum map of the supported case-sensitive string operators per the ABNF specification
+ * extended by RFC7405.
+ *
+ * The associated letter corresponds to the prefix value used within the
+ * actual ABNF grammars being parsed in order to denote either case-sensitive or case-insensitive
+ * matching for string literals.
+ */
+const CASE = {
+	SENSITIVE:   's',
+	INSENSITIVE: 'i',
+};
+
+
+
+/**
  * A map of the supported digit values, as strings, that are supported when a
  * particular numeric base is specified. In other words, if the grammar
  * specifies one of these bases for a numeric value or range, only values
@@ -44,6 +59,9 @@ const NUMERIC_DIGITS = {
  */
 var CURRENT_ID = 0;
 
+function hasCaseSensitiveOperator(char) {
+	return char === CASE.SENSITIVE || char === CASE.INSENSITIVE;
+}
 
 class Node {
 
@@ -181,9 +199,13 @@ class Node {
 					this.parseString();
 					break;
 
-				// % will always correspond to the start of a numeric literal.
+				// % will always correspond to the start of a numeric literal or a case-sensitive string.
 				case '%':
-					this.parseNumeric();
+					if (hasCaseSensitiveOperator(this.string[this.index + 1])) {
+						this.parseString()
+					} else {
+						this.parseNumeric();
+					}
 					break;
 
 				// The following tokens will always correspond to the start of
@@ -306,9 +328,17 @@ class Node {
 		var
 			token            = '',
 			found_end_quotes = false,
-			start_position   = this.index;
+			start_position   = this.index,
+			caseSensitive    = false;
 
-		// Advance past the initial double quotes:
+		// Advance past the case-sensitive operator if present (%s or %i)
+		if (hasCaseSensitiveOperator(this.string[this.index + 1])) {
+			this.index++;
+			caseSensitive = this.string[this.index] === CASE.SENSITIVE
+			this.index++;
+		}
+
+		// Advance past the initial double quotes or case-sensitive operator:
 		this.index++;
 
 		while (this.index < this.position + this.length) {
@@ -334,7 +364,8 @@ class Node {
 			.setString(this.getString())
 			.setPosition(start_position)
 			.setLength(this.index - start_position)
-			.setQuotedString(token);
+			.setQuotedString(token)
+			.setCaseSensitive(caseSensitive);
 
 		return this.addChildNode(child_node);
 	}
@@ -917,6 +948,15 @@ class Node {
 
 	hasQuotedString() {
 		return this.getQuotedString() !== null;
+	}
+
+	setCaseSensitive(bool) {
+		this.caseSensitive = bool;
+		return this;
+	}
+
+	isCaseSensitive() {
+		return this.caseSensitive;
 	}
 
 	getChildNodes() {

--- a/test/module.js
+++ b/test/module.js
@@ -4,7 +4,7 @@ var
 
 
 function parseOneQuotedString(test) {
-	test.expect(10);
+	test.expect(26);
 
 	WithQuotedString: {
 		let parser = Heket.createParser(`
@@ -68,6 +68,43 @@ function parseOneQuotedString(test) {
 			test.equals(error.getValue(), 'xx');
 			test.equals(error.getRuleName(), 'bar');
 		}
+	}
+
+	WithExplicitCaseSensitivity: {
+		let parser = Heket.createParser(`
+			rulename = %s"aBc"
+		`);
+
+		const validCases = ['aBc']
+		const invalidCases = ["abc", "Abc", "abC", "ABc", "aBC", "AbC", "ABC"]
+
+		validCases.forEach(input => {
+			const match = parser.parse(input)
+			test.deepEqual(match.getRawResult(), {
+				string: 'aBc',
+				rules: []
+			})
+		})
+
+		invalidCases.forEach(input => {
+			test.throws(() => parser.parse(input))
+		})
+	}
+
+	WithExplicitCaseInsensitivity: {
+		let parser = Heket.createParser(`
+			rulename = %i"aBc"
+		`);
+
+		const validCases = ['aBc', "abc", "Abc", "abC", "ABc", "aBC", "AbC", "ABC"]
+
+		validCases.forEach(input => {
+			const match = parser.parse(input)
+			test.deepEqual(match.getRawResult(), {
+				string: input,
+				rules: []
+			})
+		})
 	}
 
 	test.done();

--- a/test/unparser.js
+++ b/test/unparser.js
@@ -8,7 +8,7 @@ function unparseValid(test) {
 
 	var spec = `
 		foo = 1*bar *(" " baz) [wat]
-		bar = "bam"
+		bar = %s"Bam"
 		baz = "bal"
 		wat = "WAT"
 	`;
@@ -25,7 +25,7 @@ function unparseValid(test) {
 				if (bar_index < 5) {
 					test.equals(bar_index, index);
 					bar_index++;
-					return 'bam';
+					return 'Bam';
 				}
 
 				return null;
@@ -45,7 +45,7 @@ function unparseValid(test) {
 		}
 	});
 
-	test.equals(string, 'bambambambambam bal bal bal');
+	test.equals(string, 'BamBamBamBamBam bal bal bal');
 	test.done();
 }
 


### PR DESCRIPTION
These extensions to RFC5234 are documented here:
https://www.rfc-editor.org/rfc/rfc7405.html

The code has been changed to introduce the following modifications to string literal matching:
* %s"literal" - case-sensitive match of "literal"
* %i"literal" - case-insensitive match of "literal"