### PR TITLE
fix deprecation warnings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"nodeunit": "^0.11.1"
 	},
 	"scripts": {
+		"start": "node index",
 		"test": "./bin/test"
 	},
 	"types": "./index.d.ts"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"nodeunit": "^0.11.1"
 	},
 	"scripts": {
-		"start": "node index",
 		"test": "./bin/test"
 	},
 	"types": "./index.d.ts"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"version": "1.4.1",
 	"license": "ISC",
 	"repository": "https://github.com/pachet/heket.git",
-	"main": "node index",
 	"devDependencies": {
 		"nodeunit": "^0.11.1"
 	},


### PR DESCRIPTION
## Context
This warning shown at runtime after install`heket`, running with Node 18:
`[DEP0128] DeprecationWarning: Invalid 'main' field in '/project/node_modules/heket/package.json' of 'node index'. Please either fix that or report it to the module author`

## Description
- Remove `main` from `package.json`
- Add `start` script to replace main

From [npm doc](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#main), default behaviour is running `index.js` at root so should not break compatibility.